### PR TITLE
Disable HTTPS on Dashboard to enable external one separately

### DIFF
--- a/services/kubernetes_dashboard/helm.tf
+++ b/services/kubernetes_dashboard/helm.tf
@@ -26,6 +26,11 @@ resource "helm_release" "kubernetes_dashboard" {
     value = "kubernetes-dashboard"
   }
 
+  set {
+    name  = "protocolHttp"
+    value = "true"
+  }
+
   values = [
     (var.ingress_hostname != "") && var.ingress_enabled ? local.ingress_config : "",
   ]

--- a/services/kubernetes_dashboard/locals.tf
+++ b/services/kubernetes_dashboard/locals.tf
@@ -1,6 +1,5 @@
 locals {
   ingress_config = yamlencode({
-    "protocolHttp" = true,
     "extraArgs" : [
       "--enable-insecure-login"
     ],


### PR DESCRIPTION
This fake SSL cert has always been a pain as I couldn't use latest Chrome versions to access to Dashboard.
It also complicate things when enabling an external cert through cert-manager.

I have a working version of Dashboard using cert-manager but it needs testing and a better configuration handling on services/kubernetes_dashboard/locals.tf I will figure out that later on.