### PR TITLE
Remove dependencies that caused redundant updates

### DIFF
--- a/service_cert_manager.tf
+++ b/service_cert_manager.tf
@@ -14,5 +14,4 @@ module "cert_manager" {
   lets_encrypt_default_certificate_type = var.cert_manager_lets_encrypt_default_certificate_type
   dns_public_zone_names                 = local.dns_public_zone_names
 
-  depends_on = [module.eks_cluster]
 }

--- a/service_cluster_autoscaler.tf
+++ b/service_cluster_autoscaler.tf
@@ -8,7 +8,5 @@ module "cluster_autoscaler" {
   oidc_provider_arn       = module.eks_cluster.oidc_provider_arn
   cluster_oidc_issuer_url = module.eks_cluster.cluster_oidc_issuer_url
 
-  depends_on = [module.eks_cluster]
-
   tags = var.tags
 }

--- a/service_external_dns.tf
+++ b/service_external_dns.tf
@@ -11,5 +11,4 @@ module "external_dns" {
   dns_public_zone_names        = local.dns_public_zone_names
   istio_gateway_source_enabled = var.istio_enabled
 
-  depends_on = [module.eks_cluster]
 }


### PR DESCRIPTION
Removing uncontrolled updates on IAM resources. The order during deployment seems to be fine without the depends_on on modules. This caused all the IAM resources on those modules to update on any cluster update.