### PR TITLE
Add tolerations to FluentBit

### DIFF
--- a/service_fluentbit_cwlogs.tf
+++ b/service_fluentbit_cwlogs.tf
@@ -2,8 +2,10 @@ module "fluentbit_cloudwatchlogs" {
   count  = var.fluentbit_cloudwatchlogs_enabled ? 1 : 0
   source = "./services/fluentbit_cwlogs"
 
-  chart_version = var.fluentbit_cloudwatchlogs_chart_version
-  image_tag     = var.fluentbit_cloudwatchlogs_image_tag
+  chart_version         = var.fluentbit_cloudwatchlogs_chart_version
+  image_tag             = var.fluentbit_cloudwatchlogs_image_tag
+  toleration_noschedule = var.fluentbit_cloudwatchlogs_toleration_noschedule
+
 
   log_group_name    = var.fluentbit_cloudwatchlogs_log_group_name
   retention_in_days = var.fluentbit_cloudwatchlogs_retention_in_days

--- a/services/fluentbit_cwlogs/helm.tf
+++ b/services/fluentbit_cwlogs/helm.tf
@@ -57,8 +57,17 @@ resources:
   limits:
     memory: 500Mi
   requests:
-    cpu: 500m
+    cpu: 256m
     memory: 500Mi
+
+%{if length(var.toleration_noschedule) > 0}
+tolerations:
+%{endif}
+%{for key in var.toleration_noschedule}
+  - key: ${key}
+    operator: Exists
+    effect: NoSchedule
+%{endfor}
 CONFIG
 }
 

--- a/services/fluentbit_cwlogs/variables.tf
+++ b/services/fluentbit_cwlogs/variables.tf
@@ -38,3 +38,9 @@ variable "oidc_provider_arn" {
 variable "cluster_oidc_issuer_url" {
   type = string
 }
+
+variable "toleration_noschedule" {
+  description = "List of keys to add to pod tolerations"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -475,6 +475,12 @@ variable "fluentbit_cloudwatchlogs_retention_in_days" {
   type        = number
 }
 
+variable "fluentbit_cloudwatchlogs_toleration_noschedule" {
+  description = "List of keys to add to pod tolerations (e.g.: mycompany.com/compute_profile). It will be added as 'operator: Exists' and 'effect: NoSchedule'"
+  type        = list(string)
+  default     = []
+}
+
 ###
 ## AWS Cloudwatch metrics
 ###


### PR DESCRIPTION
In order to get all the logs in a node shipped to Cloudwatch, FluentBit has to be present on that node. This will help to enable taint tolerations on a list of keys.